### PR TITLE
Pildi viite parandus

### DIFF
--- a/materjalid/2_TMP36_temperatuuriandur.md
+++ b/materjalid/2_TMP36_temperatuuriandur.md
@@ -26,7 +26,7 @@ $voldid=sensori\_{näit}*(5/1023)$
 
 $temperatuur=(voldid-0.5)*100$
 
-![alt text](meedia\TMP36näide.png)
+![alt text](meedia/TMP36näide.png)
 [Interaktiivne simulatsioon](https://www.tinkercad.com/things/aYrG2vh1uUn-tmp36?sharecode=k2pp1kucaxTrZC0PG6rnkitRuZ47a5o3cB9-ljA1rHg)
 
 Näitekood:


### PR DESCRIPTION
Dokumendis pildi viites kaldkriips tagurpidi - VS Code sisseehitatud eelvvade küll näitab pilti ka sellisel juhul, kuid GitHubi vaates näitas vigast viidet.